### PR TITLE
feat/eucm projection

### DIFF
--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -14,6 +14,7 @@ jobs:
       - name: Sphinx build
         run: |
           sphinx-build docs _build
+          echo "tartanair.org" > _build/CNAME
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3
         if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tartanair"
-version = "1.0.2"
+version = "1.0.4"
 authors = [
   { name="Yorai Shaoul", email="yorai@cmu.edu" },
   { name="Wenshan Wang", email="wenshanw@cs.cmu.edu " } 
@@ -33,7 +33,9 @@ dependencies = [
     "PyYAML",
     "scipy",
     "pyyaml",
-    "pandas"
+    "pandas",
+    "imageio",
+    "einops"
     ]
 
 [project.urls]

--- a/tartanair/customizer.py
+++ b/tartanair/customizer.py
@@ -24,7 +24,7 @@ from .tartanair_module import TartanAirModule
 # Image resampling.
 from .image_resampling.image_sampler import SixPlanarNumba
 
-from .image_resampling.mvs_utils.camera_models import Pinhole, DoubleSphere, LinearSphere, Equirectangular
+from .image_resampling.mvs_utils.camera_models import Pinhole, DoubleSphere, LinearSphere, Equirectangular, PinholeRadTanFast, EUCM
 from .image_resampling.mvs_utils.shape_struct import ShapeStruct
 from .image_resampling.image_sampler.blend_function import BlendBy2ndOrderGradTorch
 
@@ -37,7 +37,12 @@ class TartanAirCustomizer(TartanAirModule):
         self.data_root = tartanair_data_root
 
         # Available camera models.
-        self.camera_model_name_to_class = {'pinhole': Pinhole, 'doublesphere': DoubleSphere, 'linearsphere': LinearSphere, 'equirect': Equirectangular}
+        self.camera_model_name_to_class = {'pinhole': Pinhole, 
+                                           'doublesphere': DoubleSphere, 
+                                           'linearsphere': LinearSphere, 
+                                           'equirect': Equirectangular,
+                                           'radtan': PinholeRadTanFast,
+                                           'eucm': EUCM}
 
     def customize(self, env, difficulty = [], trajectory_id = [], modality = [], new_camera_models_params = [], R_raw_new = np.eye(4), num_workers = 1, device = 'cpu'):
         ###############################

--- a/tartanair/eval_utils/trajectory_evaluator_base.py
+++ b/tartanair/eval_utils/trajectory_evaluator_base.py
@@ -25,7 +25,7 @@ class TrajectoryEvaluatorBase():
 
         # Set up the plot directory.
         if not plot_gfp :
-            self.plot_gfp  = os.path.dirname(est_traj)
+            self.plot_gfp  = "./"
         else:
             self.plot_gfp  = plot_gfp
 

--- a/tartanair/tartanair.py
+++ b/tartanair/tartanair.py
@@ -105,8 +105,9 @@ def customize(env, difficulty, trajectory_id, modality, new_camera_models_params
 
     * 'pinhole': A pinhole camera model.
     * 'doublesphere': A wide-angle camera model with a double sphere distortion model. Source: https://arxiv.org/abs/1807.08957
-    * 'linearsphere': A wide-angle camera model with a custom "linear sphere" distortion model.
+    * 'linearsphere': A wide-angle camera model with a custom "linear sphere" distortion model. There is a constant azimuth/elevation delta between vertical/horizontal lines.
     * 'equirect': An equirectangular camera model.
+    * 'eucm': Enhanced Unified Camera Model. Source: https://ieeexplore.ieee.org/document/7342909
     
     :param env: The environment to customize. Can be a list of environments.
     :type env: str or list
@@ -118,7 +119,7 @@ def customize(env, difficulty, trajectory_id, modality, new_camera_models_params
     :type modality: str or list
     :param new_camera_models_params: A list of dictionaries containing the parameters for the new camera models. Each dictionary should contain the following keys:
             
-        * `name`: The name of the camera model. Valid camera models are: `pinhole`, `doublesphere`, `linearsphere`, `equirect`.
+        * `name`: The name of the camera model. Valid camera models are: `pinhole`, `doublesphere`, `linearsphere`, `equirect`, `eucm`.
         * `raw_side`: The raw camera side. Can be one of `left`, `right`.
         * `R_raw_new`: The rotation matrix from the raw camera frame, with z pointing out of the image frame, x right, y down, to the new camera frame.
         * `params`: A dictionary containing the parameters for the new camera model. The parameters for each camera model are:
@@ -126,6 +127,8 @@ def customize(env, difficulty, trajectory_id, modality, new_camera_models_params
             * `doublesphere`: `fx`, `fy`, `cx`, `cy`, `height`, `width`, `xi`, `alpha`, `fov_degree`.
             * `linearsphere`: `fx`, `fy`, `cx`, `cy`, `height`, `width`, `fov_degree`.
             * `equirect`: `height`, `width`.
+            * `eucm`: `fx`, `fy`, `cx`, `cy`, `height`, `width`, `alpha`, `beta`, `fov_degree`.
+            
     :type new_camera_models_params: list
     :param num_workers: The number of workers to use for the customizer. Default is 1.
     :type num_workers: int


### PR DESCRIPTION
Short PR allows synthesis of images in more camera models, as well as adding missing code for deployment (keeping the CNAME file).