### PR TITLE
Added missing pose modality

### DIFF
--- a/tartanair/tartanair_module.py
+++ b/tartanair/tartanair_module.py
@@ -48,7 +48,7 @@ class TartanAirModule():
 
         self.camera_directions = ["front", "right", "back", "left", "top", "bottom"]
 
-        self.modality_names = ['image', 'depth', 'seg', 'imu', 'lidar', 'flow', 'event']
+        self.modality_names = ['image', 'depth', 'seg', 'imu', 'lidar', 'flow', 'event', 'pose']
 
         self.cam_modalities = ['image', 'depth', 'seg'] # the modalities that support all camera names
 


### PR DESCRIPTION
As mentioned in https://github.com/castacks/tartanairpy/issues/73 the dataloader fails if the "pose" modality is requested. This change simply adds it to the list of modalities in https://github.com/castacks/tartanairpy/blob/fd7108778b9d943411efb297765348823bf1542c/tartanair/tartanair_module.py#L51 which results in the pose being loaded alongside with the images, depths, etc. 